### PR TITLE
Unconditionally set somaxconns on task definitions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,9 @@
 - Make sure you are using the latest major version of Go (run `go version` to check).
 - Fork the repository.
 - Clone your forked repository into your `$GOPATH` (run `go env GOPATH` to find out)
-  - `git clone git@github.com:<user>/aws/amazon-ecs-cli $GOPATH/src/github.com/aws/amazon-ecs-cli`
+  - `git clone git@github.com:memfault/memfault-ecs-cli $GOPATH/src/github.com/aws/amazon-ecs-cli`
   - **NOTE:** replace `<user>` with your Github username.
+  - **NOTE:** the destination into which you clone this matters. You will only be able to build successfully if the repo is at `$GOPATH/src/github.com/aws/amazon-ecs-cli`
 - Turn off Go modules with `export GO111MODULE=off` since we use [dep](https://github.com/golang/dep) to manage dependencies. Make sure you have version 0.5.4 of [dep](https://github.com/golang/dep/releases/tag/v0.5.4) (installation instructions [here](https://golang.github.io/dep/docs/installation.html)). You can also run `make generate-deps` to install the latest version of dep as well as other tools.
 
 #### Set upstream

--- a/ecs-cli/modules/cli/compose/entity/entity_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/entity_helper.go
@@ -134,6 +134,21 @@ func createRegisterTaskDefinitionRequest(taskDefinition *ecs.TaskDefinition, tag
 		PlacementConstraints:    taskDefinition.PlacementConstraints,
 	}
 
+	// 2023-11 Unconditionally set somaxconns at the task ContainerDefinition level.
+	if len(taskDefinition.ContainerDefinitions) > 0 {
+		for _, containerDefinition := range taskDefinition.ContainerDefinitions {
+			namespace := "net.core.somaxconn"
+			value := "2048"
+			systemControl := &ecs.SystemControl{
+				Namespace : &namespace,
+				Value : &value,
+			}
+			systemControls := []*ecs.SystemControl{systemControl}
+			containerDefinition.SetSystemControls(systemControls)
+		}
+
+	}
+
 	if networkMode := taskDefinition.NetworkMode; aws.StringValue(networkMode) != "" {
 		request.NetworkMode = networkMode
 	}


### PR DESCRIPTION
This PR sets somaxconn to 2048 unconditionally on any container definition. 2048 was chosen to match the [default backlog value in gunicorn](https://docs.gunicorn.org/en/stable/settings.html#backlog)

Below are all services which leverage ecs-cli for deployment:
<img width="766" alt="Screenshot 2023-11-20 at 4 10 56 PM" src="https://github.com/memfault/memfault-ecs-cli/assets/7935795/9a6c4483-556b-4eeb-8a87-3e2bd7408b63">

All of these share an AMI, so they should have values of 128 as their default. We'd like this value set on all web services, and it should be harmless to run on workers as those should not generally have huge numbers of socket connections.

Once approved, we'll need to ensure this binary is built and distributed to all engineers who act as release sheriff as well as modifying `install-ecs-cli.sh` to pull our forked binary, which will let the codedeploy pipeline set these values as well.

[ ] - TODO: Make sure this is safe for logspout
[ ] - TODO: Document specific make requirements (directory structure is weird since I renamed the repo in order to make it private, but all the deps ref the old name)
  - `git clone git@github.com:memfault/memfault-ecs-cli.git /Users/dansubak/go/src/github.com/aws/amazon-ecs-cli`

# Testing
- Built via `make` on my M1 Mac
- I've [manually run a services_apply](https://memfault.slack.com/archives/CQ2UUSE3V/p1700504430851579?thread_ts=1700499677.598529&cid=CQ2UUSE3V) against staging and observed that the value was correctly set in the task definition.