### PR TITLE
Conditionalize systemcontrols value setting on the use of awsvpc network mode

### DIFF
--- a/ecs-cli/modules/cli/compose/entity/entity_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/entity_helper.go
@@ -134,8 +134,12 @@ func createRegisterTaskDefinitionRequest(taskDefinition *ecs.TaskDefinition, tag
 		PlacementConstraints:    taskDefinition.PlacementConstraints,
 	}
 
+	if networkMode := taskDefinition.NetworkMode; aws.StringValue(networkMode) != "" {
+		request.NetworkMode = networkMode
+	}
+
 	// 2023-11 Unconditionally set somaxconns at the task ContainerDefinition level.
-	if len(taskDefinition.ContainerDefinitions) > 0 {
+	if len(taskDefinition.ContainerDefinitions)  > 0 && aws.StringValue(taskDefinition.NetworkMode)  == "awsvpc" {
 		for _, containerDefinition := range taskDefinition.ContainerDefinitions {
 			namespace := "net.core.somaxconn"
 			value := "2048"
@@ -147,10 +151,6 @@ func createRegisterTaskDefinitionRequest(taskDefinition *ecs.TaskDefinition, tag
 			containerDefinition.SetSystemControls(systemControls)
 		}
 
-	}
-
-	if networkMode := taskDefinition.NetworkMode; aws.StringValue(networkMode) != "" {
-		request.NetworkMode = networkMode
 	}
 
 	if cpu := taskDefinition.Cpu; aws.StringValue(cpu) != "" {

--- a/ecs-cli/modules/cli/compose/entity/entity_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/entity_helper.go
@@ -138,7 +138,7 @@ func createRegisterTaskDefinitionRequest(taskDefinition *ecs.TaskDefinition, tag
 		request.NetworkMode = networkMode
 	}
 
-	// 2023-11 Unconditionally set somaxconns at the task ContainerDefinition level.
+	// 2023-11 Conditionally set somaxconns at the task ContainerDefinition level.
 	if len(taskDefinition.ContainerDefinitions)  > 0 && aws.StringValue(taskDefinition.NetworkMode)  == "awsvpc" {
 		for _, containerDefinition := range taskDefinition.ContainerDefinitions {
 			namespace := "net.core.somaxconn"


### PR DESCRIPTION
Unfortunately we do specify at least a few services which have an ecs_network_mode of `host` - task definitions with that mode cannot have SystemControls within the network namespace set. This change just checks for a networking mode of `awsvpc` before attempting to set somaxconn kernel tunings.

### Test Plan
- `make docker-build` to ensure everything compiles
- run `services-apply` against one of our logging services, ensure that it succeeds and does not attempt to specify a somaxconn value in the task definition.
- Run against the same command staging web tasks and ensure that somaxconn value is present